### PR TITLE
Fixes #1776, Vox Welding Helmet now Visible

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -29,7 +29,7 @@
 	loose = 4
 	species_fit = list("Vox")
 	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/eyes.dmi'
+		"Vox" = 'icons/mob/species/vox/head.dmi'
 		)
 
 /obj/item/clothing/head/welding/attack_self()


### PR DESCRIPTION
Title explains the whole PR, for whatever reason it was looking for the sprite in the eyes section instead of the head section.

However, this turned up another issue. The mask's UP state is the exact same sprite as that for humans-- which looks just odd on Vox. I'll look further into that